### PR TITLE
allow specific grpc error code to be returned from GetAuthRequest

### DIFF
--- a/server/external_authorizer.go
+++ b/server/external_authorizer.go
@@ -98,6 +98,14 @@ func (s *GrpcFrameworkServer) externalAuthorizerUnaryInterceptor(
 		}
 		authZReq, handlerData, err := authZReqGetter.GetAuthZRequest(ctx, info.FullMethod, apiRequest)
 		if err != nil {
+			st, ok := status.FromError(err)
+			if ok {
+				log.WithContext(ctx).WithFields(logrus.Fields{
+					"method": "externalAuthorizerUnaryInterceptor",
+					"code":   st.Code().String(),
+				}).Warningf("failed to get authZ request, status: %v", err.Error())
+				return nil, err
+			}
 			return nil, auditLogErrorf(codes.Internal, "failed to get authZ request: %v", err)
 		}
 		switch authZReq {


### PR DESCRIPTION
**What this PR does / why we need it**:
If the err is gRPC status, propagate it out to the client. This allows specific errors such as InvalidArguments to be returned along with a friendly error message.

Signed-off-by: Neelesh Thakur <neelesh.thakur@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->



**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

