### PR TITLE
Add support for MultiClientID Authenticators.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 test/app/bin
 .vscode
 client
-server
 venv

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -61,7 +61,7 @@ type Authenticator interface {
 // and clientID.
 type MultiAuthenticatorWithClientID interface {
 	Authenticator
-	GetAuthenticator(issuer, clientID string) Authenticator
+	GetAuthenticators(issuer string) []Authenticator
 	ListIssuersWithClientID() []IssuerWithClientID
 }
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -56,7 +56,16 @@ type Authenticator interface {
 	Username(*Claims) string
 }
 
-// Enabled returns whether or not auth is enabled.
+// MultiAuthenticatorWithClientID is a wrapper over the Authenticator interface
+// to manage multiple such authenticators based on the unique combination of issuer
+// and clientID.
+type MultiAuthenticatorWithClientID interface {
+	Authenticator
+	GetAuthenticator(issuer, clientID string) Authenticator
+	ListIssuersWithClientID() []IssuerWithClientID
+}
+
+// Enabled returns whether auth is enabled.
 func Enabled() bool {
 	return len(systemTokenInst.Issuer()) != 0
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -62,7 +62,7 @@ type Authenticator interface {
 type MultiAuthenticatorWithClientID interface {
 	Authenticator
 	GetAuthenticators(issuer string) []Authenticator
-	ListIssuersWithClientID() []IssuerWithClientID
+	ListIssuers() []string
 }
 
 // Enabled returns whether auth is enabled.

--- a/pkg/auth/claims.go
+++ b/pkg/auth/claims.go
@@ -36,6 +36,8 @@ type Claims struct {
 	Name string `json:"name" yaml:"name"`
 	// Account email
 	Email string `json:"email" yaml:"email"`
+	// Audience is the intended audience for this claim
+	Audience string `json:"aud" yaml:"aud"`
 	// Roles of this account
 	Roles []string `json:"roles,omitempty" yaml:"roles,omitempty"`
 	// (optional) Groups in which this account is part of

--- a/pkg/auth/multiauthenticator.go
+++ b/pkg/auth/multiauthenticator.go
@@ -11,19 +11,18 @@ type multiAuthenticatorImpl struct {
 
 // NewMultiAuthenticator maintains a list of authenticators for a given issuer.
 // The input argument is a map of issuers to a list of authenticators for that issuer.
-// NOTE: This interface does not check if there are duplicate authenticators.
+// NOTE: This interface does not check if there are duplicate authenticators. The interface
+// will own the input map and will not create a copy of it.
 func NewMultiAuthenticator(
 	authenticators map[string][]Authenticator,
 ) (MultiAuthenticatorWithClientID, error) {
-	authMap := make(map[string][]Authenticator)
 	for issuer, authenticatorsList := range authenticators {
 		if len(authenticatorsList) == 0 {
 			return nil, fmt.Errorf("empty authenticators list for issuer %v", issuer)
 		}
-		authMap[issuer] = authenticatorsList
 	}
 	return &multiAuthenticatorImpl{
-		authenticators: authMap,
+		authenticators: authenticators,
 	}, nil
 }
 

--- a/pkg/auth/multiauthenticator.go
+++ b/pkg/auth/multiauthenticator.go
@@ -1,0 +1,67 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type IssuerWithClientID struct {
+	Issuer   string // Issuer of the token.
+	ClientID string // ClientID of the token, can be empty.
+}
+
+type multiAuthenticatorWithClientIDImpl struct {
+	authenticators map[IssuerWithClientID]Authenticator
+}
+
+func NewMultiAuthenticatorWithClientID(
+	authenticators map[IssuerWithClientID]Authenticator) MultiAuthenticatorWithClientID {
+	return &multiAuthenticatorWithClientIDImpl{
+		authenticators: authenticators,
+	}
+}
+
+// GetAuthenticator returns nil if there is no authenticator for the given issuer and client ID.
+func (m *multiAuthenticatorWithClientIDImpl) GetAuthenticator(issuer, audience string) Authenticator {
+	for issuerWithClientID, authenticator := range m.authenticators {
+		// Audience field in a claim can contain more than just the clientID.
+		// The strings.Contains check here is same as what is being used by the OIDC library
+		// which verifies the token.
+		if issuer == issuerWithClientID.Issuer && strings.Contains(audience, issuerWithClientID.ClientID) {
+			return authenticator
+		}
+	}
+	return nil
+}
+
+func (m *multiAuthenticatorWithClientIDImpl) ListIssuersWithClientID() []IssuerWithClientID {
+	var issuerWithClientIDs []IssuerWithClientID
+	for issuerWithClientID, _ := range m.authenticators {
+		issuerWithClientIDs = append(issuerWithClientIDs, issuerWithClientID)
+	}
+	return issuerWithClientIDs
+}
+
+func (m *multiAuthenticatorWithClientIDImpl) AuthenticateToken(ctx context.Context, accessToken string) (*Claims, error) {
+	claims, err := TokenClaims(accessToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get claims from token: %w", err)
+	}
+
+	authenticator := m.GetAuthenticator(claims.Issuer, claims.Audience)
+	if authenticator == nil {
+		return nil, fmt.Errorf("no authenticator found for issuer %s & audience %s", claims.Issuer, claims.Audience)
+	}
+
+	return authenticator.AuthenticateToken(ctx, accessToken)
+}
+
+func (m *multiAuthenticatorWithClientIDImpl) Username(claims *Claims) string {
+	authenticator := m.GetAuthenticator(claims.Issuer, claims.Audience)
+	if authenticator == nil {
+		return ""
+	}
+
+	return authenticator.Username(claims)
+}

--- a/pkg/auth/multiauthenticator.go
+++ b/pkg/auth/multiauthenticator.go
@@ -3,12 +3,13 @@ package auth
 import (
 	"context"
 	"fmt"
-	"strings"
 )
 
 type IssuerWithClientID struct {
-	Issuer   string // Issuer of the token.
-	ClientID string // ClientID of the token, can be empty.
+	// Issuer of the token. The issuer cannot be empty.
+	Issuer string
+	// ClientID of the token. The clientID cannot be empty.
+	ClientID string
 }
 
 type multiAuthenticatorWithClientIDImpl struct {
@@ -16,23 +17,20 @@ type multiAuthenticatorWithClientIDImpl struct {
 }
 
 func NewMultiAuthenticatorWithClientID(
-	authenticators map[IssuerWithClientID]Authenticator) MultiAuthenticatorWithClientID {
-	return &multiAuthenticatorWithClientIDImpl{
-		authenticators: authenticators,
-	}
-}
-
-// GetAuthenticator returns nil if there is no authenticator for the given issuer and client ID.
-func (m *multiAuthenticatorWithClientIDImpl) GetAuthenticator(issuer, audience string) Authenticator {
-	for issuerWithClientID, authenticator := range m.authenticators {
-		// Audience field in a claim can contain more than just the clientID.
-		// The strings.Contains check here is same as what is being used by the OIDC library
-		// which verifies the token.
-		if issuer == issuerWithClientID.Issuer && strings.Contains(audience, issuerWithClientID.ClientID) {
-			return authenticator
+	authenticators map[IssuerWithClientID]Authenticator) (MultiAuthenticatorWithClientID, error) {
+	authMap := make(map[IssuerWithClientID]Authenticator)
+	for issuerWithClientID, authenticator := range authenticators {
+		if issuerWithClientID.ClientID == "" {
+			return nil, fmt.Errorf("clientID cannot be empty")
 		}
+		if issuerWithClientID.Issuer == "" {
+			return nil, fmt.Errorf("issuer cannot be empty")
+		}
+		authMap[issuerWithClientID] = authenticator
 	}
-	return nil
+	return &multiAuthenticatorWithClientIDImpl{
+		authenticators: authMap,
+	}, nil
 }
 
 func (m *multiAuthenticatorWithClientIDImpl) ListIssuersWithClientID() []IssuerWithClientID {
@@ -43,25 +41,41 @@ func (m *multiAuthenticatorWithClientIDImpl) ListIssuersWithClientID() []IssuerW
 	return issuerWithClientIDs
 }
 
-func (m *multiAuthenticatorWithClientIDImpl) AuthenticateToken(ctx context.Context, accessToken string) (*Claims, error) {
-	claims, err := TokenClaims(accessToken)
+func (m *multiAuthenticatorWithClientIDImpl) GetAuthenticators(issuer string) []Authenticator {
+	var authenticators []Authenticator
+	for issuerWithClientID, authenticator := range m.authenticators {
+		if issuerWithClientID.Issuer == issuer {
+			authenticators = append(authenticators, authenticator)
+		}
+	}
+	return authenticators
+}
+
+func (m *multiAuthenticatorWithClientIDImpl) AuthenticateToken(ctx context.Context, idToken string) (*Claims, error) {
+	tokenClaims, err := TokenClaims(idToken)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get claims from token: %w", err)
 	}
 
-	authenticator := m.GetAuthenticator(claims.Issuer, claims.Audience)
-	if authenticator == nil {
-		return nil, fmt.Errorf("no authenticator found for issuer %s & audience %s", claims.Issuer, claims.Audience)
+	for _, authenticator := range m.GetAuthenticators(tokenClaims.Issuer) {
+		claims, err := authenticator.AuthenticateToken(ctx, idToken)
+		if err == nil {
+			return claims, nil
+		}
 	}
 
-	return authenticator.AuthenticateToken(ctx, accessToken)
+	return nil, fmt.Errorf("failed to authenticate token for issuer %v and audience %v",
+		tokenClaims.Issuer, tokenClaims.Audience)
 }
 
 func (m *multiAuthenticatorWithClientIDImpl) Username(claims *Claims) string {
-	authenticator := m.GetAuthenticator(claims.Issuer, claims.Audience)
-	if authenticator == nil {
-		return ""
+	var username string
+	// TODO: This code does not handle the case where there are mulitple authenticators
+	// registered with the same issuer but different UsernameClaimTypes.
+	for _, authenticator := range m.GetAuthenticators(claims.Issuer) {
+		if username = authenticator.Username(claims); username != "" {
+			return username
+		}
 	}
-
-	return authenticator.Username(claims)
+	return username
 }

--- a/pkg/auth/multiauthenticator_test.go
+++ b/pkg/auth/multiauthenticator_test.go
@@ -1,0 +1,135 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultiAuthenticatorWithClientID_GetAuthenticator_Ok(t *testing.T) {
+	// Given.
+	jwtAuth, err := NewJwtAuthenticator(&JwtAuthConfig{
+		SharedSecret:  []byte("my-secret"),
+		UsernameClaim: UsernameClaimTypeSubject,
+	})
+	assert.NoError(t, err)
+	m := NewMultiAuthenticatorWithClientID(map[IssuerWithClientID]Authenticator{IssuerWithClientID{"issuer-1", "1"}: jwtAuth})
+
+	// When.
+	found := m.GetAuthenticator("issuer-1", "1")
+
+	// Then.
+	assert.NotNil(t, found)
+}
+
+func TestMultiAuthenticatorWithClientID_GetAuthenticator_FailNoClientId(t *testing.T) {
+	// Given.
+	jwtAuth, err := NewJwtAuthenticator(&JwtAuthConfig{
+		SharedSecret:  []byte("my-secret"),
+		UsernameClaim: UsernameClaimTypeSubject,
+	})
+	assert.NoError(t, err)
+	m := NewMultiAuthenticatorWithClientID(map[IssuerWithClientID]Authenticator{
+		IssuerWithClientID{"issuer-1", "1"}: jwtAuth,
+	})
+
+	// When.
+	found := m.GetAuthenticator("issuer-1", "2")
+
+	// Then.
+	assert.Nil(t, found)
+}
+
+func TestMultiAuthenticatorWithClientID_GetAuthenticator_FailNoIssuer(t *testing.T) {
+	// Given.
+	m := NewMultiAuthenticatorWithClientID(map[IssuerWithClientID]Authenticator{})
+
+	// When.
+	found := m.GetAuthenticator("issuer-1", "1")
+
+	// Then.
+	assert.Nil(t, found)
+}
+
+func TestMultiAuthenticatorWithClientID_AuthenticateToken_Ok(t *testing.T) {
+	// Given.
+	jwtAuth1, err := NewJwtAuthenticator(&JwtAuthConfig{
+		SharedSecret:  []byte("my-secret-1"),
+		UsernameClaim: UsernameClaimTypeSubject,
+	})
+	assert.NoError(t, err)
+
+	m := NewMultiAuthenticatorWithClientID(map[IssuerWithClientID]Authenticator{
+		IssuerWithClientID{"issuer-1", "1"}: jwtAuth1,
+		IssuerWithClientID{"issuer-1", "2"}: jwtAuth1,
+	})
+
+	rawToken, err := Token(&Claims{
+		Audience: "1",
+		Issuer:   "issuer-1",
+		Email:    "my@email.com",
+		Name:     "my-name",
+		Subject:  "my-sub",
+		Roles:    []string{"tester"},
+	}, &Signature{
+		Type: jwt.SigningMethodHS256,
+		Key:  []byte("my-secret-1"),
+	}, &Options{
+		Expiration: time.Now().Add(time.Minute * 10).Unix(),
+	})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, rawToken)
+
+	// When.
+	authenticateClaims, err := m.AuthenticateToken(context.Background(), rawToken)
+
+	// Then.
+	assert.NoError(t, err)
+	assert.Equal(t, "issuer-1", authenticateClaims.Issuer)
+	assert.Equal(t, "my@email.com", authenticateClaims.Email)
+	assert.Equal(t, "my-name", authenticateClaims.Name)
+	assert.Equal(t, []string{"tester"}, authenticateClaims.Roles)
+}
+
+func TestMultiAuthenticatorWithClientID_AuthenticateTokenMultiAud_Ok(t *testing.T) {
+	// Given.
+	jwtAuth1, err := NewJwtAuthenticator(&JwtAuthConfig{
+		SharedSecret:  []byte("my-secret-1"),
+		UsernameClaim: UsernameClaimTypeSubject,
+	})
+	assert.NoError(t, err)
+
+	m := NewMultiAuthenticatorWithClientID(map[IssuerWithClientID]Authenticator{
+		IssuerWithClientID{"issuer-1", ""}:          jwtAuth1,
+		IssuerWithClientID{"issuer-1", "clientID2"}: jwtAuth1,
+	})
+
+	rawToken, err := Token(&Claims{
+		Issuer:   "issuer-1",
+		Email:    "my@email.com",
+		Name:     "my-name",
+		Subject:  "my-sub",
+		Roles:    []string{"tester"},
+		Audience: "extra info & clientID2",
+	}, &Signature{
+		Type: jwt.SigningMethodHS256,
+		Key:  []byte("my-secret-1"),
+	}, &Options{
+		Expiration: time.Now().Add(time.Minute * 10).Unix(),
+	})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, rawToken)
+
+	// When.
+	authenticateClaims, err := m.AuthenticateToken(context.Background(), rawToken)
+
+	// Then.
+	assert.NoError(t, err)
+	assert.Equal(t, "issuer-1", authenticateClaims.Issuer)
+	assert.Equal(t, "my@email.com", authenticateClaims.Email)
+	assert.Equal(t, "my-name", authenticateClaims.Name)
+	assert.Equal(t, []string{"tester"}, authenticateClaims.Roles)
+}

--- a/pkg/auth/multiauthenticator_test.go
+++ b/pkg/auth/multiauthenticator_test.go
@@ -9,49 +9,60 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMultiAuthenticatorWithClientID_GetAuthenticator_Ok(t *testing.T) {
+func TestNewMultiAuthenticatorWithClientID_EmptyClientID(t *testing.T) {
 	// Given.
 	jwtAuth, err := NewJwtAuthenticator(&JwtAuthConfig{
 		SharedSecret:  []byte("my-secret"),
 		UsernameClaim: UsernameClaimTypeSubject,
 	})
 	assert.NoError(t, err)
-	m := NewMultiAuthenticatorWithClientID(map[IssuerWithClientID]Authenticator{IssuerWithClientID{"issuer-1", "1"}: jwtAuth})
-
-	// When.
-	found := m.GetAuthenticator("issuer-1", "1")
-
-	// Then.
-	assert.NotNil(t, found)
+	m, err := NewMultiAuthenticatorWithClientID(map[IssuerWithClientID]Authenticator{IssuerWithClientID{"issuer-1", ""}: jwtAuth})
+	assert.Error(t, err)
+	assert.Nil(t, m)
 }
 
-func TestMultiAuthenticatorWithClientID_GetAuthenticator_FailNoClientId(t *testing.T) {
+func TestNewMultiAuthenticatorWithClientID_EmptyIssuer(t *testing.T) {
 	// Given.
 	jwtAuth, err := NewJwtAuthenticator(&JwtAuthConfig{
 		SharedSecret:  []byte("my-secret"),
 		UsernameClaim: UsernameClaimTypeSubject,
 	})
 	assert.NoError(t, err)
-	m := NewMultiAuthenticatorWithClientID(map[IssuerWithClientID]Authenticator{
-		IssuerWithClientID{"issuer-1", "1"}: jwtAuth,
+	m, err := NewMultiAuthenticatorWithClientID(map[IssuerWithClientID]Authenticator{IssuerWithClientID{"", "1"}: jwtAuth})
+	assert.Error(t, err)
+	assert.Nil(t, m)
+}
+
+func TestMultiAuthenticatorWithClientID_GetAuthenticators_Ok(t *testing.T) {
+	// Given.
+	jwtAuth, err := NewJwtAuthenticator(&JwtAuthConfig{
+		SharedSecret:  []byte("my-secret"),
+		UsernameClaim: UsernameClaimTypeSubject,
 	})
+	assert.NoError(t, err)
+	m, err := NewMultiAuthenticatorWithClientID(map[IssuerWithClientID]Authenticator{
+		IssuerWithClientID{"issuer-1", "1"}: jwtAuth,
+		IssuerWithClientID{"issuer-1", "2"}: jwtAuth,
+	})
+	assert.NoError(t, err)
 
 	// When.
-	found := m.GetAuthenticator("issuer-1", "2")
+	authenticators := m.GetAuthenticators("issuer-1")
 
 	// Then.
-	assert.Nil(t, found)
+	assert.Equal(t, 2, len(authenticators))
 }
 
 func TestMultiAuthenticatorWithClientID_GetAuthenticator_FailNoIssuer(t *testing.T) {
 	// Given.
-	m := NewMultiAuthenticatorWithClientID(map[IssuerWithClientID]Authenticator{})
+	m, err := NewMultiAuthenticatorWithClientID(map[IssuerWithClientID]Authenticator{})
+	assert.NoError(t, err)
 
 	// When.
-	found := m.GetAuthenticator("issuer-1", "1")
+	authenticators := m.GetAuthenticators("issuer-1")
 
 	// Then.
-	assert.Nil(t, found)
+	assert.Empty(t, authenticators)
 }
 
 func TestMultiAuthenticatorWithClientID_AuthenticateToken_Ok(t *testing.T) {
@@ -62,10 +73,11 @@ func TestMultiAuthenticatorWithClientID_AuthenticateToken_Ok(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	m := NewMultiAuthenticatorWithClientID(map[IssuerWithClientID]Authenticator{
+	m, err := NewMultiAuthenticatorWithClientID(map[IssuerWithClientID]Authenticator{
 		IssuerWithClientID{"issuer-1", "1"}: jwtAuth1,
 		IssuerWithClientID{"issuer-1", "2"}: jwtAuth1,
 	})
+	assert.NoError(t, err)
 
 	rawToken, err := Token(&Claims{
 		Audience: "1",
@@ -74,46 +86,6 @@ func TestMultiAuthenticatorWithClientID_AuthenticateToken_Ok(t *testing.T) {
 		Name:     "my-name",
 		Subject:  "my-sub",
 		Roles:    []string{"tester"},
-	}, &Signature{
-		Type: jwt.SigningMethodHS256,
-		Key:  []byte("my-secret-1"),
-	}, &Options{
-		Expiration: time.Now().Add(time.Minute * 10).Unix(),
-	})
-	assert.NoError(t, err)
-	assert.NotEmpty(t, rawToken)
-
-	// When.
-	authenticateClaims, err := m.AuthenticateToken(context.Background(), rawToken)
-
-	// Then.
-	assert.NoError(t, err)
-	assert.Equal(t, "issuer-1", authenticateClaims.Issuer)
-	assert.Equal(t, "my@email.com", authenticateClaims.Email)
-	assert.Equal(t, "my-name", authenticateClaims.Name)
-	assert.Equal(t, []string{"tester"}, authenticateClaims.Roles)
-}
-
-func TestMultiAuthenticatorWithClientID_AuthenticateTokenMultiAud_Ok(t *testing.T) {
-	// Given.
-	jwtAuth1, err := NewJwtAuthenticator(&JwtAuthConfig{
-		SharedSecret:  []byte("my-secret-1"),
-		UsernameClaim: UsernameClaimTypeSubject,
-	})
-	assert.NoError(t, err)
-
-	m := NewMultiAuthenticatorWithClientID(map[IssuerWithClientID]Authenticator{
-		IssuerWithClientID{"issuer-1", ""}:          jwtAuth1,
-		IssuerWithClientID{"issuer-1", "clientID2"}: jwtAuth1,
-	})
-
-	rawToken, err := Token(&Claims{
-		Issuer:   "issuer-1",
-		Email:    "my@email.com",
-		Name:     "my-name",
-		Subject:  "my-sub",
-		Roles:    []string{"tester"},
-		Audience: "extra info & clientID2",
 	}, &Signature{
 		Type: jwt.SigningMethodHS256,
 		Key:  []byte("my-secret-1"),

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -82,6 +82,21 @@ func TokenIssuer(rawtoken string) (string, error) {
 	}
 }
 
+// TokenAudience returns the audience from the raw JWT token.
+func TokenAudience(rawtoken string) (string, error) {
+	claims, err := TokenClaims(rawtoken)
+	if err != nil {
+		return "", err
+	}
+
+	// Return issuer
+	if len(claims.Audience) != 0 {
+		return claims.Audience, nil
+	} else {
+		return "", fmt.Errorf("audience was not specified in the token")
+	}
+}
+
 // IsJwtToken returns true if the provided string is a valid jwt token
 func IsJwtToken(authstring string) bool {
 	_, _, err := new(jwt.Parser).ParseUnverified(authstring, jwt.MapClaims{})
@@ -103,6 +118,7 @@ func Token(
 		"roles": claims.Roles,
 		"iat":   time.Now().Add(-options.IATSubtract).Unix(),
 		"exp":   options.Expiration,
+		"aud":   claims.Audience,
 	}
 	if claims.Groups != nil {
 		mapclaims["groups"] = claims.Groups

--- a/server/grpc_framework_server.go
+++ b/server/grpc_framework_server.go
@@ -81,8 +81,8 @@ func NewGrpcFrameworkServer(config *ServerConfig) (*GrpcFrameworkServer, error) 
 		return nil, fmt.Errorf("must supply role manager when authentication is enabled and default authZ is used")
 	}
 	if config.Security.Authenticators != nil {
-		for _, issuerWithClientID := range config.Security.Authenticators.ListIssuersWithClientID() {
-			log.Infof("Authentication enabled for issuer: %s with clientID %s", issuerWithClientID.Issuer, issuerWithClientID.ClientID)
+		for _, issuer := range config.Security.Authenticators.ListIssuers() {
+			log.Infof("Authentication enabled for issuer: %s ", issuer)
 		}
 	}
 

--- a/server/grpc_framework_server.go
+++ b/server/grpc_framework_server.go
@@ -70,19 +70,19 @@ func NewGrpcFrameworkServer(config *ServerConfig) (*GrpcFrameworkServer, error) 
 	})
 
 	// Setup authentication
+
+	// Check the necessary security config options are set. Authentication is enabled. Therefore,
+	// either RoleManager must be provided (this implies use of the default authZ)
+	// or explicit authZ interceptors must be provided
+	// or external authZ checker must be provided (this implies use of external_authorizer.go)
+	if config.Security.Authenticators != nil && config.Security.Role == nil &&
+		(config.AuthZUnaryInterceptor == nil || config.AuthZStreamInterceptor == nil) &&
+		config.ExternalAuthZChecker == nil {
+		return nil, fmt.Errorf("must supply role manager when authentication is enabled and default authZ is used")
+	}
 	if config.Security.Authenticators != nil {
 		for _, issuerWithClientID := range config.Security.Authenticators.ListIssuersWithClientID() {
 			log.Infof("Authentication enabled for issuer: %s with clientID %s", issuerWithClientID.Issuer, issuerWithClientID.ClientID)
-
-			// Check the necessary security config options are set. Authentication is enabled. Therefore,
-			// either RoleManager must be provided (this implies use of the default authZ)
-			// or explicit authZ interceptors must be provided
-			// or external authZ checker must be provided (this implies use of external_authorizer.go)
-			if config.Security.Role == nil &&
-				(config.AuthZUnaryInterceptor == nil || config.AuthZStreamInterceptor == nil) &&
-				config.ExternalAuthZChecker == nil {
-				return nil, fmt.Errorf("must supply role manager when authentication is enabled and default authZ is used")
-			}
 		}
 	}
 
@@ -141,7 +141,7 @@ func (s *GrpcFrameworkServer) Start() error {
 	// use caller's authN interceptor if provided
 	if s.config.AuthNUnaryInterceptor != nil {
 		unaryInterceptors = append(unaryInterceptors, s.config.AuthNUnaryInterceptor)
-	} else if s.config.Security.Authenticators != nil && len(s.config.Security.Authenticators.ListIssuersWithClientID()) > 0 {
+	} else if s.config.Security.Authenticators != nil {
 		// use the default authN interceptor
 		unaryInterceptors = append(unaryInterceptors, grpc_auth.UnaryServerInterceptor(s.auth))
 	}
@@ -154,7 +154,7 @@ func (s *GrpcFrameworkServer) Start() error {
 		// plug the caller-supplied authChecker into our external authorizer framework
 		unaryInterceptors = append(unaryInterceptors, s.externalAuthorizerUnaryInterceptor(
 			s.config.ExternalAuthZChecker, s.config.InsecureNoAuthNAuthZReqs, s.config.InsecureNoAuthZReqs))
-	} else if s.config.Security.Authenticators != nil && len(s.config.Security.Authenticators.ListIssuersWithClientID()) > 0 {
+	} else if s.config.Security.Authenticators != nil {
 		// use our default authZ interceptor
 		unaryInterceptors = append(unaryInterceptors, s.authorizationServerUnaryInterceptor)
 	}
@@ -173,7 +173,7 @@ func (s *GrpcFrameworkServer) Start() error {
 	// use caller's authN interceptor if provided
 	if s.config.AuthNStreamInterceptor != nil {
 		streamInterceptors = append(streamInterceptors, s.config.AuthNStreamInterceptor)
-	} else if s.config.Security.Authenticators != nil && len(s.config.Security.Authenticators.ListIssuersWithClientID()) > 0 {
+	} else if s.config.Security.Authenticators != nil {
 		// use the default authN interceptor
 		streamInterceptors = append(streamInterceptors, grpc_auth.StreamServerInterceptor(s.auth))
 	}
@@ -186,7 +186,7 @@ func (s *GrpcFrameworkServer) Start() error {
 		// plug the caller-supplied authChecker into our external authorizer interceptor
 		streamInterceptors = append(streamInterceptors, s.externalAuthorizerStreamInterceptor(
 			s.config.ExternalAuthZChecker, s.config.InsecureNoAuthNAuthZReqs, s.config.InsecureNoAuthZReqs))
-	} else if s.config.Security.Authenticators != nil && len(s.config.Security.Authenticators.ListIssuersWithClientID()) > 0 {
+	} else if s.config.Security.Authenticators != nil {
 		// use our default authZ interceptor
 		streamInterceptors = append(streamInterceptors, s.authorizationServerStreamInterceptor)
 	}

--- a/server/grpc_framework_server.go
+++ b/server/grpc_framework_server.go
@@ -70,17 +70,19 @@ func NewGrpcFrameworkServer(config *ServerConfig) (*GrpcFrameworkServer, error) 
 	})
 
 	// Setup authentication
-	for issuer := range config.Security.Authenticators {
-		log.Infof("Authentication enabled for issuer: %s", issuer)
+	if config.Security.Authenticators != nil {
+		for _, issuerWithClientID := range config.Security.Authenticators.ListIssuersWithClientID() {
+			log.Infof("Authentication enabled for issuer: %s with clientID %s", issuerWithClientID.Issuer, issuerWithClientID.ClientID)
 
-		// Check the necessary security config options are set. Authentication is enabled. Therefore,
-		// either RoleManager must be provided (this implies use of the default authZ)
-		// or explicit authZ interceptors must be provided
-		// or external authZ checker must be proviced (this implies use of external_authorizer.go)
-		if config.Security.Role == nil &&
-			(config.AuthZUnaryInterceptor == nil || config.AuthZStreamInterceptor == nil) &&
-			config.ExternalAuthZChecker == nil {
-			return nil, fmt.Errorf("must supply role manager when authentication is enabled and default authZ is used")
+			// Check the necessary security config options are set. Authentication is enabled. Therefore,
+			// either RoleManager must be provided (this implies use of the default authZ)
+			// or explicit authZ interceptors must be provided
+			// or external authZ checker must be provided (this implies use of external_authorizer.go)
+			if config.Security.Role == nil &&
+				(config.AuthZUnaryInterceptor == nil || config.AuthZStreamInterceptor == nil) &&
+				config.ExternalAuthZChecker == nil {
+				return nil, fmt.Errorf("must supply role manager when authentication is enabled and default authZ is used")
+			}
 		}
 	}
 
@@ -139,7 +141,7 @@ func (s *GrpcFrameworkServer) Start() error {
 	// use caller's authN interceptor if provided
 	if s.config.AuthNUnaryInterceptor != nil {
 		unaryInterceptors = append(unaryInterceptors, s.config.AuthNUnaryInterceptor)
-	} else if len(s.config.Security.Authenticators) > 0 {
+	} else if s.config.Security.Authenticators != nil && len(s.config.Security.Authenticators.ListIssuersWithClientID()) > 0 {
 		// use the default authN interceptor
 		unaryInterceptors = append(unaryInterceptors, grpc_auth.UnaryServerInterceptor(s.auth))
 	}
@@ -152,7 +154,7 @@ func (s *GrpcFrameworkServer) Start() error {
 		// plug the caller-supplied authChecker into our external authorizer framework
 		unaryInterceptors = append(unaryInterceptors, s.externalAuthorizerUnaryInterceptor(
 			s.config.ExternalAuthZChecker, s.config.InsecureNoAuthNAuthZReqs, s.config.InsecureNoAuthZReqs))
-	} else if len(s.config.Security.Authenticators) > 0 {
+	} else if s.config.Security.Authenticators != nil && len(s.config.Security.Authenticators.ListIssuersWithClientID()) > 0 {
 		// use our default authZ interceptor
 		unaryInterceptors = append(unaryInterceptors, s.authorizationServerUnaryInterceptor)
 	}
@@ -171,7 +173,7 @@ func (s *GrpcFrameworkServer) Start() error {
 	// use caller's authN interceptor if provided
 	if s.config.AuthNStreamInterceptor != nil {
 		streamInterceptors = append(streamInterceptors, s.config.AuthNStreamInterceptor)
-	} else if len(s.config.Security.Authenticators) > 0 {
+	} else if s.config.Security.Authenticators != nil && len(s.config.Security.Authenticators.ListIssuersWithClientID()) > 0 {
 		// use the default authN interceptor
 		streamInterceptors = append(streamInterceptors, grpc_auth.StreamServerInterceptor(s.auth))
 	}
@@ -184,7 +186,7 @@ func (s *GrpcFrameworkServer) Start() error {
 		// plug the caller-supplied authChecker into our external authorizer interceptor
 		streamInterceptors = append(streamInterceptors, s.externalAuthorizerStreamInterceptor(
 			s.config.ExternalAuthZChecker, s.config.InsecureNoAuthNAuthZReqs, s.config.InsecureNoAuthZReqs))
-	} else if len(s.config.Security.Authenticators) > 0 {
+	} else if s.config.Security.Authenticators != nil && len(s.config.Security.Authenticators.ListIssuersWithClientID()) > 0 {
 		// use our default authZ interceptor
 		streamInterceptors = append(streamInterceptors, s.authorizationServerStreamInterceptor)
 	}

--- a/server/grpc_framework_server.go
+++ b/server/grpc_framework_server.go
@@ -82,7 +82,7 @@ func NewGrpcFrameworkServer(config *ServerConfig) (*GrpcFrameworkServer, error) 
 	}
 	if config.Security.Authenticators != nil {
 		for _, issuer := range config.Security.Authenticators.ListIssuers() {
-			log.Infof("Authentication enabled for issuer: %s ", issuer)
+			log.Infof("Authentication enabled for issuer: %s", issuer)
 		}
 	}
 

--- a/server/server_config.go
+++ b/server/server_config.go
@@ -24,9 +24,8 @@ import (
 	"github.com/libopenstorage/grpc-framework/pkg/auth"
 	"github.com/libopenstorage/grpc-framework/pkg/auth/role"
 	"github.com/rs/cors"
-	"google.golang.org/grpc"
-
 	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
 )
 
 // TLSConfig points to the cert files needed for HTTPS
@@ -43,13 +42,10 @@ type SecurityConfig struct {
 	Role role.RoleManager
 	// Tls configuration
 	Tls *TLSConfig
-	// Authenticators per issuer. You can register multple authenticators
-	// based on the "iss" string in the string. For example:
-	// map[string]auth.Authenticator {
-	//     "https://accounts.google.com": googleOidc,
-	//     "openstorage-sdk-auth: selfSigned,
-	// }
-	Authenticators map[string]auth.Authenticator
+	// Authenticators is an instance of MultiAuthenticatorWithClientID
+	// The MultiAuthenticator interface allows managing multiple
+	// authenticators. Each authenticator is tied to a unique combination of issuer + clientID.
+	Authenticators auth.MultiAuthenticatorWithClientID
 }
 
 type RestServerPrometheusConfig struct {

--- a/server/server_interceptors.go
+++ b/server/server_interceptors.go
@@ -106,7 +106,7 @@ func (s *GrpcFrameworkServer) auth(ctx context.Context) (context.Context, error)
 		})
 		return ctx, nil
 	} else {
-		return nil, auditLogWarningf(codes.PermissionDenied, err, "Unable to authenticate token")
+		return nil, auditLogWarningf(codes.Unauthenticated, err, "Unable to authenticate token")
 	}
 }
 

--- a/server/server_interceptors.go
+++ b/server/server_interceptors.go
@@ -20,11 +20,10 @@ import (
 	"fmt"
 	"time"
 
+	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	"github.com/libopenstorage/grpc-framework/pkg/auth"
 	"github.com/libopenstorage/grpc-framework/pkg/correlation"
 	grpcutil "github.com/libopenstorage/grpc-framework/pkg/grpc/util"
-
-	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	"github.com/pborman/uuid"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -75,10 +74,11 @@ func (s *GrpcFrameworkServer) auth(ctx context.Context) (context.Context, error)
 	// Audit log
 	log := correlation.NewFunctionLogger(ctx)
 	log.Out = s.auditLogOutput
-	auditLogWarningf := func(c codes.Code, format string, a ...interface{}) error {
+	auditLogWarningf := func(c codes.Code, err error, format string, a ...interface{}) error {
 		log.WithContext(ctx).WithFields(logrus.Fields{
 			"method": "Authentication",
 			"code":   c.String(),
+			"error":  err.Error(),
 		}).Warningf(format, a...)
 		return status.Errorf(c, format, a...)
 	}
@@ -91,33 +91,22 @@ func (s *GrpcFrameworkServer) auth(ctx context.Context) (context.Context, error)
 	// Obtain token from metadata in the context
 	token, err = grpc_auth.AuthFromMD(ctx, ContextMetadataTokenKey)
 	if err != nil {
-		return nil, auditLogWarningf(codes.Unauthenticated, "Invalid or missing authentication token")
-	}
-
-	// Determine issuer
-	issuer, err := auth.TokenIssuer(token)
-	if err != nil {
-		return nil, auditLogWarningf(codes.Unauthenticated, "Unable to obtain token issuer from authorization token")
+		return nil, auditLogWarningf(codes.Unauthenticated, err, "Invalid or missing authentication token")
 	}
 
 	// Authenticate user
-	if authenticator, ok := s.config.Security.Authenticators[issuer]; ok {
-		var claims *auth.Claims
-		claims, err = authenticator.AuthenticateToken(ctx, token)
-		if err == nil {
-			// Add authorization information back into the context so that other
-			// functions can get access to this information.
-			// If this is in the context is how functions will know that security is enabled.
-			ctx = auth.ContextSaveUserInfo(ctx, &auth.UserInfo{
-				Username: authenticator.Username(claims),
-				Claims:   *claims,
-			})
-			return ctx, nil
-		} else {
-			return nil, auditLogWarningf(codes.PermissionDenied, "Unable to authenticate token")
-		}
+	claims, err := s.config.Security.Authenticators.AuthenticateToken(ctx, token)
+	if err == nil {
+		// Add authorization information back into the context so that other
+		// functions can get access to this information.
+		// If this is in the context is how functions will know that security is enabled.
+		ctx = auth.ContextSaveUserInfo(ctx, &auth.UserInfo{
+			Username: s.config.Security.Authenticators.Username(claims),
+			Claims:   *claims,
+		})
+		return ctx, nil
 	} else {
-		return nil, auditLogWarningf(codes.Unauthenticated, "%s is not a trusted issuer", issuer)
+		return nil, auditLogWarningf(codes.PermissionDenied, err, "Unable to authenticate token")
 	}
 }
 


### PR DESCRIPTION

**What this PR does / why we need it**:
- The auth interceptor will choose an authenticator based on the issuer and configured clientID combination.
- From the token the clientID is checked from the audience field of the claim.
- Since audience can contain more than just the clientID, the multi authenticator does a "Contains" check for the configured clientID and the audience field.


**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

