### PR TITLE
docker: Support for arm64 and amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang
+LABEL org.opencontainers.image.authors="lpabon@purestorage.com"
+
+ENV GOPATH=/go
+RUN apt update
+
+##
+## grpc-framework additions
+##
+# Install tools
+COPY ./tools/grpcfw* /usr/local/bin/
+# Add protofiles
+RUN mkdir -p /go/src/github.com/libopenstorage/grpc-framework
+COPY . /go/src/github.com/libopenstorage/grpc-framework
+
+##
+## Install software specific to this arch
+##
+RUN bash /go/src/github.com/libopenstorage/grpc-framework/hack/docker-build.sh
+
+##
+## Set working directory
+##
+RUN mkdir -p /go/src/code
+WORKDIR /go/src/code


### PR DESCRIPTION
This change adds support to create containers for Apple M1+ arm64 processors as well as Intel/AMD amd64.

Also changes the size from 2.9GB to about 1.5GB

**What this PR does / why we need it**:
Allows development on a Apple M1+ system without emulation of the container

**Special notes for your reviewer**:

For this PR, there is a container in Quay.io with the tag `:dev`. Please try:

```
docker pull quay.io/openstorage/grpc-framework:dev
docker run -ti quay.io/openstorage/grpc-framework:dev /bin/bash
```

In the container, type:

```
uname -m
```

Notice if it shown `x86_64` for a host with x86 and `aarch64` for Apple M1+ systems.

FYI, Apple M1+ systems may require [Docker Desktop](https://www.docker.com/products/docker-desktop/)

