### PR TITLE
Update protoc-gen-validate package and docker image repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ clean:
 	$(MAKE) clean -C test/app
 
 container:
-	docker build -t quay.io/openstorage/grpc-framework:$(TAG) .
+	docker build -t docker.io/portworx/grpc-framework:$(TAG) .
 
 container-buildx-install:
 	@echo "Setting up multiarch emulation"
@@ -65,11 +65,11 @@ container-buildx-install:
 
 # Run: make container-buildx-install first to install the emulation
 container-release:
-	@echo "This will automatically push. Must be logged in to quay.io"
+	@echo "This will automatically push."
 	docker buildx build \
 		--push \
 		--platform linux/amd64,linux/arm64  \
-		--tag quay.io/openstorage/grpc-framework:$(TAG) .
+		--tag docker.io/portworx/grpc-framework:$(TAG) .
 
 container-buildx-uninstall:
 	docker buildx stop gfwbuilder

--- a/hack/docker-build.sh
+++ b/hack/docker-build.sh
@@ -89,7 +89,7 @@ RUN npm install -g swagger2openapi
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v${GFPROTOCGENGO}
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v${GFPROTOCGENGOGRPC}
 # Install protoc-gen-validate
-RUN go install github.com/envoyproxy/protoc-gen-validate
+RUN go install github.com/envoyproxy/protoc-gen-validate@latest
 # Install Google Api proto files
 RUN mkdir -p /go/src/github.com/googleapis && \
 	cd /go/src/github.com/googleapis && \


### PR DESCRIPTION
**What this PR does / why we need it:**
- Update go package protoc-gen-validate in docker image
- Update docker image registry to docker.io/portworx/grpc-framework
